### PR TITLE
adicionando auxílio-saúde

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,17 @@ Vale ressaltar que o desambiguador ainda não está pronto para ser utilizado se
 
 Para isso, faz-se necessário editar a lista de rubricas `lista_rubricas`, adicionando a nova rubrica a ser desambiguada no final do arquivo.
 
-Caso seja necessário mais de um termo para desambiguar uma determinada rubrica, basta adicionar os termos semelhantes na mesma linha separados por ponto e vírgula. Ex.:
+- Caso seja necessário mais de um termo para desambiguar uma determinada rubrica, basta adicionar os termos semelhantes na mesma linha separados por ponto e vírgula. Ex.:
+  
 ```
 licenca-premio;indenizacao-licenca-premio
+```
+
+- Caso encontre um problema de repetição de rubrica, basta adicionar **%** até a quantidade de repetições necessárias. Ex.:
+
+```
+aux-saude-magis-exerc-anterior%%
+output: "aux saude magis exerc anterior aux saude magis exerc anterior aux saude magis exerc anterior"
 ```
 
 A nova rubrica será adicionada ao arquivo `rubricas.json` com uma lista de rubricas semelhantes após execução do script.

--- a/desambiguador.py
+++ b/desambiguador.py
@@ -24,16 +24,21 @@ for rubrica in tqdm(lista_rubricas):
 
     # Desambiguamos cada termo e adicionamos a sua respectiva rubrica, isto é, o primeiro termo.
     for r in rubrica:
-        lista_desambiguada = get_close_matches(r, rubricas, n=len(rubricas), cutoff=0.7)
+        # Em alguns casos, o órgão repete o termo (ex.: aux saude aux saude) e isso dificulta o processo de desambiguação
+        # Como paliativo, o algoritmo entende a presença de % como sinal de repetição de termo
+        # Destarte, consulta entre as rubricas o mesmo termo repetido até n vezes
+        for n in range (r.count("%")+1):
+            rubrica_original = r.replace("%", "")
+            lista_desambiguada = get_close_matches(r.replace("%", rubrica_original, n), rubricas, n=len(rubricas), cutoff=0.7)
         
-        if rubrica[0] in grupos_rubricas:
-            grupos_rubricas[rubrica[0]].extend(lista_desambiguada)
-        else:
-            grupos_rubricas[rubrica[0]] = lista_desambiguada
+            if rubrica[0] in grupos_rubricas:
+                grupos_rubricas[rubrica[0]].extend(lista_desambiguada)
+            else:
+                grupos_rubricas[rubrica[0]] = lista_desambiguada
 
-    # Limpando a lista desambiguada da rubrica e mantendo apenas itens distintos.
-    grupos_rubricas[rubrica[0]] = list(set(grupos_rubricas[rubrica[0]]))
-    grupos_rubricas[rubrica[0]].sort()
+            # Limpando a lista desambiguada da rubrica e mantendo apenas itens distintos.
+            grupos_rubricas[rubrica[0]] = list(set(grupos_rubricas[rubrica[0]]))
+            grupos_rubricas[rubrica[0]].sort()
 
 # Cria arquivo .json com a lista de rubricas desambiguadas
 with open("rubricas.json", "w") as json_file:

--- a/lista_rubricas.txt
+++ b/lista_rubricas.txt
@@ -3,3 +3,4 @@ licenca-premio;indenizacao-licenca-premio;licenca-premio-lei-estadual
 indenizacao-de-ferias;ferias;ferias-indenizadas
 gratificacao-natalina
 licenca-compensatoria
+auxilio-saude;aux-saude;aux-saude-magis-exerc-anterior%%;diferenca-auxilio-saude;aux-saude-devolucao

--- a/rubricas.json
+++ b/rubricas.json
@@ -202,5 +202,19 @@
         "indenizacao licenca compensatoria",
         "licenca compensatoria",
         "licenca compensatoria pecunia"
+    ],
+    "auxilio-saude": [
+        "0272aux saude",
+        "aux saude devolucao",
+        "aux saude dif",
+        "aux saude magis exerc anterior",
+        "aux saude magis exerc anterior aux saude magis exerc anterior",
+        "aux saude magis exerc anterior aux saude magis exerc anterior aux saude magis exerc anterior",
+        "auxilio saude",
+        "auxiliosaude",
+        "dif aux saude",
+        "difauxiliosaude",
+        "diferenca auxilio saude",
+        "saude"
     ]
 }


### PR DESCRIPTION
- adicionando auxílio-saúde
- hoje encontrei um problema, essa rubrica:
```
"aux saude magis exerc anterior",
"aux saude magis exerc anterior aux saude magis exerc anterior",
"aux saude magis exerc anterior aux saude magis exerc anterior aux saude magis exerc anterior"   
```
- o fato dela se repetir n vezes dificultava o processo de desambiguação, uma vez que o algoritmo encontrava apenas o primeiro termo
- a solução proposta foi adicionar mais um caractere especial (semelhante ao **;** ), com o qual o desambiguador soubesse a necessidade de repetir e quantas vezes