### PR TITLE
removendo rubrica desambiguada errada

### DIFF
--- a/rubricas.json
+++ b/rubricas.json
@@ -242,7 +242,6 @@
         "indenizacao de licenca compensatoria magistrados dev indenizacao de licenca compensatoria magistrados",
         "indenizacao de licenca compensatoria magistrados dif indenizacao de licenca compensatoria magistrados",
         "indenizacao de licenca compensatoria magistrados indenizacao de licenca compensatoria magistrados",
-        "indenizacao de licenca premio licenca compensatoria",
         "indenizacao lic compensatoria restj 112023",
         "indenizacao lic compensatoria restj 112024",
         "indenizacao licenca compensatoria",


### PR DESCRIPTION
- A rubrica `indenizacao de licenca premio licenca compensatoria` do TJSP está desambiguada como licença-compensatória, mas tem dois benefícios juntos.